### PR TITLE
Fetch latest blflash version from git repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ rustup component add llvm-tools-preview --toolchain nightly-2022-12-25
 rustup target add riscv32imac-unknown-none-elf
 
 cargo install cargo-binutils
-cargo install cargo-blflash
+cargo install --git https://github.com/spacemeowx2/blflash cargo-blflash
 ```
 
 These commands add the required toolchain targets along with binary flashing for easy development (No need for GUIs anymore 😉).


### PR DESCRIPTION
"cargo install cargo-blflash" can install blflash 0.3.0, which requires funty 1.2.0 as a dependency. Funty 1.2 was yanked a while back (https://github.com/ferrilab/funty/issues/7)